### PR TITLE
Add conda recipe for FamDB

### DIFF
--- a/conda/build.sh
+++ b/conda/build.sh
@@ -6,11 +6,21 @@ mkdir -p "${FDB_DIR}"
 mkdir -p "${PREFIX}/bin"
 
 cp -a . "${FDB_DIR}/"
-
 chmod +x "${FDB_DIR}/famdb.py"
 
-ln -sf "${FDB_DIR}/famdb.py" "${PREFIX}/bin/famdb.py"
+# use wrapper scripts so __file__ designations resolve to the correct directories
+cat > "${PREFIX}/bin/famdb.py" << EOF
+#!/bin/bash
+exec "${FDB_DIR}/famdb.py" "\$@"
+EOF
+chmod +x "${PREFIX}/bin/famdb.py"
 
+# use wrapper scripts so __file__ designations resolve to the correct directories
 for name in "${FDB_DIR}"/utils/*; do
-    ln -sf "$name" "${PREFIX}/bin/$(basename "$name")"
+    script_name="$(basename "$name")"
+    cat > "${PREFIX}/bin/${script_name}" << EOF
+#!/bin/bash
+exec "${FDB_DIR}/utils/${script_name}" "\$@"
+EOF
+    chmod +x "${PREFIX}/bin/${script_name}"
 done

--- a/conda/build.sh
+++ b/conda/build.sh
@@ -1,0 +1,16 @@
+#!/bin/bash
+
+FDB_DIR="${PREFIX}/share/${PKG_NAME}-${PKG_VERSION}"
+
+mkdir -p "${FDB_DIR}"
+mkdir -p "${PREFIX}/bin"
+
+cp -a . "${FDB_DIR}/"
+
+chmod +x "${FDB_DIR}/famdb.py"
+
+ln -sf "${FDB_DIR}/famdb.py" "${PREFIX}/bin/famdb.py"
+
+for name in "${FDB_DIR}"/utils/*; do
+    ln -sf "$name" "${PREFIX}/bin/$(basename "$name")"
+done

--- a/conda/meta.yaml
+++ b/conda/meta.yaml
@@ -1,0 +1,36 @@
+{% set name = "famdb" %}
+{% set version = "3.0.0" %}
+
+package:
+  name: {{ name }}
+  version: {{ version }}
+
+source:
+  url: https://github.com/Dfam-consortium/FamDB/archive/refs/tags/{{ version }}.tar.gz
+  sha256: cad4652696cbd6b3444ef1ea008764e4807eba503410bf24357c4505a5ddb8d4
+
+build:
+  number: 0
+  noarch: generic
+  run_exports:
+    - {{ pin_subpackage(name, max_pin="x.x") }}
+
+requirements:
+  run:
+    - python >=3.9
+    - h5py
+
+test:
+  commands:
+    - famdb.py -h
+
+about:
+  home: "https://github.com/Dfam-consortium/FamDB/"
+  license: "Open Software License v2.1"
+  summary: "FamDB is a modular HDF5-based export format and query tool developed for offline access to the Dfam database of transposable element and repetitive DNA families."
+  doc_url: "https://github.com/Dfam-consortium/FamDB/"
+  dev_url: "https://github.com/Dfam-consortium/FamDB/"
+
+extra:
+  recipe-maintainers:
+    - TobyBaril


### PR DESCRIPTION
In respones to issue #27 

Here is the conda recipe for an install of FamDB into conda environments. With this, users cloning the repo will be able to build the package for themselves (`conda build ./conda/`) and then use this in their local environments (`conda install famdb --use-local`). This also makes it possible to incorporate FamDB into pipelines and packages that require it as a dependency whilst reducing manual intervention for the end user.

I've built and tested this locally, as well as configured libraries etc with RepeatMasker and RepeatModeler and the package functions as expected. All scripts are sourced using wrapper scripts in the `bin` of the conda env, allowing users to call, e.g. `download_dfam.py`, without needed a full path, whilst preserving the expected output of python calls in the code (i.e. `__file__`).